### PR TITLE
Fatigue support

### DIFF
--- a/pCrunch/__init__.py
+++ b/pCrunch/__init__.py
@@ -5,7 +5,7 @@ __email__ = ["nikhar.abbas@nrel.gov", "jake.nunemaker@nrel.gov"]
 
 
 from ._version import get_versions
-from .analysis import LoadsAnalysis, PowerProduction
+from .analysis import LoadsAnalysis, PowerProduction, FatigueParams
 
 __version__ = get_versions()["version"]
 del get_versions

--- a/pCrunch/analysis.py
+++ b/pCrunch/analysis.py
@@ -441,7 +441,7 @@ class LoadsAnalysis:
         #DEL = curve.find_miner_sum(np.c_[Frf, Nrf]) ** (1 / slope)
 
         # Compute Palmgren/Miner damage using stress
-        D = np.nan # default return value
+        D = 0.0 # default return value
         if return_damage and load2stress > 0.0:
             try:
                 S, Mrf = fatpack.find_rainflow_ranges(ts*load2stress, return_means=True)

--- a/pCrunch/analysis.py
+++ b/pCrunch/analysis.py
@@ -379,6 +379,7 @@ class LoadsAnalysis:
         for chan, fatparams in self._fc.items():
 
             try:
+
                 DELs[chan], D[chan] = self._compute_del(
                     output[chan], output.elapsed_time,
                     fatparams.lifetime,
@@ -436,8 +437,8 @@ class LoadsAnalysis:
             F, Fmean = fatpack.find_rainflow_ranges(ts, return_means=True)
         except:
             F = Fmean = np.zeros(1)
-        if goodman and load2stress > 0.0:
-            F = fatpack.find_goodman_equivalent_stress(F, Fmean, Sult/load2stress)
+        if goodman and np.abs(load2stress) > 0.0:
+            F = fatpack.find_goodman_equivalent_stress(F, Fmean, Sult/np.abs(load2stress))
         Nrf, Frf = fatpack.find_range_count(F, bins)
         DELs = Frf ** slope * Nrf / elapsed
         DEL = DELs.sum() ** (1.0 / slope)
@@ -449,7 +450,7 @@ class LoadsAnalysis:
 
         # Compute Palmgren/Miner damage using stress
         D = np.nan # default return value
-        if return_damage and load2stress > 0.0:
+        if return_damage and np.abs(load2stress) > 0.0:
             try:
                 S, Mrf = fatpack.find_rainflow_ranges(ts*load2stress, return_means=True)
             except:

--- a/pCrunch/io/openfast.py
+++ b/pCrunch/io/openfast.py
@@ -98,9 +98,12 @@ class OpenFASTBase:
             if new_chan in self.channels:
                 print(f"Channel '{new_chan}' already exists.")
                 continue
-
-            arrays = np.array([self[a] for a in chans]).T
-            normed = np.linalg.norm(arrays, axis=1).reshape(arrays.shape[0], 1)
+            try:
+                arrays = np.array([self[a] for a in chans]).T
+                normed = np.linalg.norm(arrays, axis=1).reshape(arrays.shape[0], 1)
+            except:
+                normed = np.nan * np.ones((self.data.shape[0],1))
+                
             self.data = np.append(self.data, normed, axis=1)
             self.channels = np.append(self.channels, new_chan)
 


### PR DESCRIPTION
Enables calculation of stress-based fatigue damage (not just DELs) by passing in the parameters of the S-N curve and the conversion from load-stress.  This supports parallel PRs in WISDEM & WEIS.

@JakeNunemaker : I ended up going a slightly different route that what you had coded up, but the changes you made were a perfect template for what I needed to do.