### PR TITLE
Parallel Read and Fix Rainflow Counting Issue

### DIFF
--- a/pCrunch/__init__.py
+++ b/pCrunch/__init__.py
@@ -1,4 +1,4 @@
 from .crunch import Crunch
 from .fatigue import FatigueParams
-from .openfast_readers import OpenFASTAscii, OpenFASTBinary, load_FAST_out, read
+from .openfast_readers import OpenFASTAscii, OpenFASTBinary, load_FAST_out, read, read_parallel
 from .aeroelastic_output import AeroelasticOutput

--- a/pCrunch/fatigue.py
+++ b/pCrunch/fatigue.py
@@ -301,7 +301,7 @@ class FatigueParams:
         """
 
         try:
-            S, Mrf = fatpack.find_rainflow_ranges(chan, k=128, return_means=True)
+            S, Mrf = fatpack.find_rainflow_ranges(chan, k=256, return_means=True)
         except Exception:
             S = Mrf = np.zeros(1)
             

--- a/pCrunch/openfast_readers.py
+++ b/pCrunch/openfast_readers.py
@@ -35,6 +35,29 @@ def read(filename, **kwargs):
         return fastout
     else:
         return fastout[0]
+    
+def read_parallel(filenames, n_cores=1, **kwargs):
+    """
+    Read OpenFAST files in parallel.
+
+    Parameters
+    ----------
+    filenames : list of str
+        List of OpenFAST file paths.
+    n_cores : int, optional
+        Number of cores to use for parallel reading. Default is 1.
+
+    Returns
+    -------
+    list of OpenFASTOutput
+        List of OpenFASTOutput instances.
+    """
+    
+    import multiprocessing
+    with multiprocessing.Pool(n_cores) as pool:
+        outputs = pool.map(read, filenames, **kwargs)
+    
+    return outputs
 
     
 def load_FAST_out(filenames, tmin=0, tmax=float('inf'), **kwargs):


### PR DESCRIPTION
Fixes issue in WEIS CI: https://github.com/WISDEM/WEIS/actions/runs/17865395593/job/50806345035?pr=426#step:10:15827

For reference: https://github.com/Gunnstein/fatpack/blob/82d4aeef031f803d09edb1893a6c4587fa3adfd2/fatpack/rainflow.py#L446

We could also use `find_rainflow_ranges_strict` in fatpack, which also worked.

In the short WEIS tests, there is not always a full cycle to measure, and for some reason, it returns duplicate cycle ranges.

The parallel read function is just a trivial application of the `read` function using multiprocessing, but it helps when parsing several files.  